### PR TITLE
Fix filter pagination

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -589,7 +589,11 @@ class Admin extends React.Component {
         value,
         this.state.queryset
       );
-      this.setState({ queryset: queryset });
+      this.setState({
+        queryset: queryset,
+        total: queryset.length,
+        page_number: 1
+      });
     }
   }
   render_filters() {

--- a/src/admin.js
+++ b/src/admin.js
@@ -886,7 +886,7 @@ class Admin extends React.Component {
   selectPage(page) {
     return event => {
       this.setState({ page_number: page.page }, () => {
-        // no needed if pagination is done on frontend
+        // not needed if pagination is done on frontend
         this.setState({
           queryset: this.get_queryset(
             this.state.page_number,

--- a/src/admin.js
+++ b/src/admin.js
@@ -886,6 +886,7 @@ class Admin extends React.Component {
   selectPage(page) {
     return event => {
       this.setState({ page_number: page.page }, () => {
+        // no needed if pagination is done on frontend
         this.setState({
           queryset: this.get_queryset(
             this.state.page_number,


### PR DESCRIPTION
First of all: awesome project! 👏This is by far the easiest solution I can find on the internet to build a CRUD GUI that can be easily tweaked and extended.

Two issues I have found during my implementation:

1. The page number is not reset to 1 after filtering, which is counter-intuitive: it doesn't make sense to stay on page x (x>1) after selecting a new filter.
2. I fetch all records from backend, then do pagination on frontend. Thus the second setState in **selectPage** leads to a wrong result (get_queryset will fetch another whole set of records). In my case, I removed that callback and all is good. So I left a comment there.