### PR TITLE
Add utility function clearFilters

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -635,10 +635,13 @@ class Admin extends React.Component {
   }
 
   /**
-   * This function clears filters, searches, selected, and pagination states
+   * This function clears filters, searches, select, and pagination states
    */
   clearFilters() {
+    // Fetch the initial query set
+    // This depends on how pagination is implemented
     this.get_queryset(1, 9999, []);
+
     this.state.selected_objects.items.forEach(item =>
       this.state.selected_objects.remove(item)
     );

--- a/src/admin.js
+++ b/src/admin.js
@@ -90,6 +90,7 @@ class Admin extends React.Component {
     this._select_one = this._select_one.bind(this);
     this.response_change = this.response_change.bind(this);
     this.response_add = this.response_add.bind(this);
+    this.clearFilters = this.clearFilters.bind(this);
   }
   /**
    * This function returns an array of objects that will serve as the
@@ -632,6 +633,29 @@ class Admin extends React.Component {
       </div>
     );
   }
+
+  /**
+   * This function clears filters, searches, selected, and pagination states
+   */
+  clearFilters() {
+    this.get_queryset(1, 9999, []);
+    this.state.selected_objects.items.forEach(item =>
+      this.state.selected_objects.remove(item)
+    );
+    this.setState({
+      filter_values: [],
+      page_number: 1,
+      appliedFilters: [],
+      selected_objects: this.state.selected_objects
+    });
+    // clear search term
+    var searchInput = document.querySelector("[name=search]");
+    var allBoxes = document.querySelector("#all_boxes");
+    searchInput && (searchInput.value = "");
+    // hacky way to clear all boxes check mark
+    allBoxes && allBoxes.checked && allBoxes.click();
+  }
+
   sort_by(sort_fields) {
     return this.state.queryset ? this.state.queryset : [];
   }


### PR DESCRIPTION
The easiest way for a user to bail from the existing scoped-down result is to wipe out all criteria: including filters applied, search words, pagination state, and checkboxes (including the "all" box on top).
It's basically a less painful way for a user to reload the page.
<img width="329" alt="Screen Shot 2019-07-12 at 5 26 36 AM" src="https://user-images.githubusercontent.com/4952113/61117944-aba6d380-a465-11e9-871d-5c138f70bb19.png">
